### PR TITLE
Places irk-scale-question-step min/max text below the slider

### DIFF
--- a/www/lib/ionic-researchkit/ionic-researchkit.css
+++ b/www/lib/ionic-researchkit/ionic-researchkit.css
@@ -64,6 +64,10 @@
   height: 100% !important;
 }
 
+.irk-slider .range {
+  justify-content: space-between;
+}
+
 .irk-slider-slide {
   padding-top: 80px;
   color: #000;

--- a/www/lib/ionic-researchkit/ionic-researchkit.js
+++ b/www/lib/ionic-researchkit/ionic-researchkit.js
@@ -811,12 +811,14 @@ angular.module('ionicResearchKit',[])
                     '<div class="irk-spacer"></div>'+
                     '<h3>{{$parent.formData.'+attr.id+' || \'&nbsp;\'}}</h3>'+
                     '<div class="range">'+
+                    '<input type="range" name="'+attr.id+'" min="'+attr.min+'" max="'+attr.max+'" step="'+attr.step+'" value="'+attr.value+'" ng-model="$parent.formData.'+attr.id+'" ng-required="'+(attr.optional=='false'?'true':'false')+'" ng-change="$parent.dirty()">'+
+                    '</div><div class="range"><p>'+
                     attr.min+
                     (attr.minText?'<br>'+attr.minText:'')+
-                    '<input type="range" name="'+attr.id+'" min="'+attr.min+'" max="'+attr.max+'" step="'+attr.step+'" value="'+attr.value+'" ng-model="$parent.formData.'+attr.id+'" ng-required="'+(attr.optional=='false'?'true':'false')+'" ng-change="$parent.dirty()">'+
+                    '</p><p>'+
                     attr.max+
                     (attr.maxText?'<br>'+attr.maxText:'')+
-                    '</div>'+
+                    '</p></div>'+
                     '</form>'
         },
         link: function(scope, element, attrs, controller) {


### PR DESCRIPTION
When using ionic-researchKit on iOS and Android device in portrait mode, the slider was squished between the min and max text:

<img width="439" alt="screen shot 2017-03-16 at 5 58 44 pm" src="https://cloud.githubusercontent.com/assets/964880/24128592/1baea76c-0d9a-11e7-875a-abc89ee39f5a.png">

I propose to place the min/max text below the slider:

<img width="436" alt="screen shot 2017-03-16 at 5 55 12 pm" src="https://cloud.githubusercontent.com/assets/964880/24128621/4ec9526e-0d9a-11e7-863b-a5fc0a8ad9e3.png">
